### PR TITLE
Removed `echo` step from the codebase. Closes #35

### DIFF
--- a/modconfig/flowpipe_loop.go
+++ b/modconfig/flowpipe_loop.go
@@ -17,8 +17,6 @@ type LoopDefn interface {
 
 func GetLoopDefn(stepType string) LoopDefn {
 	switch stepType {
-	case schema.BlockTypePipelineStepEcho:
-		return &LoopEchoStep{}
 	case schema.BlockTypePipelineStepHttp:
 		return &LoopHttpStep{}
 	case schema.BlockTypePipelineStepSleep:
@@ -120,30 +118,6 @@ func (l *LoopQueryStep) UpdateInput(input Input, evalContext *hcl.EvalContext) (
 
 func (*LoopQueryStep) GetType() string {
 	return schema.BlockTypePipelineStepQuery
-}
-
-type LoopEchoStep struct {
-	Until   bool    `json:"until" hcl:"until" cty:"until"`
-	Numeric *int    `json:"numeric,omitempty" hcl:"numeric,optional" cty:"numeric"`
-	Text    *string `json:"text,omitempty" hcl:"text,optional" cty:"text"`
-}
-
-func (l *LoopEchoStep) UpdateInput(input Input, evalContext *hcl.EvalContext) (Input, error) {
-	if l.Numeric != nil {
-		input["numeric"] = *l.Numeric
-	}
-	if l.Text != nil {
-		input["text"] = *l.Text
-	}
-	return input, nil
-}
-
-func (l *LoopEchoStep) UntilReached() bool {
-	return l.Until
-}
-
-func (*LoopEchoStep) GetType() string {
-	return schema.BlockTypePipelineStepEcho
 }
 
 type LoopHttpStep struct {

--- a/modconfig/flowpipe_pipeline.go
+++ b/modconfig/flowpipe_pipeline.go
@@ -268,13 +268,6 @@ func (ph *Pipeline) UnmarshalJSON(data []byte) error {
 				}
 				ph.Steps = append(ph.Steps, &step)
 
-			case schema.BlockTypePipelineStepEcho:
-				var step PipelineStepEcho
-				if err := json.Unmarshal(stepData, &step); err != nil {
-					return err
-				}
-				ph.Steps = append(ph.Steps, &step)
-
 			case schema.BlockTypePipelineStepTransform:
 				var step PipelineStepTransform
 				if err := json.Unmarshal(stepData, &step); err != nil {

--- a/modconfig/flowpipe_pipeline_schema.go
+++ b/modconfig/flowpipe_pipeline_schema.go
@@ -558,53 +558,6 @@ var PipelineStepQueryBlockSchema = &hcl.BodySchema{
 	},
 }
 
-var PipelineStepEchoBlockSchema = &hcl.BodySchema{
-	Attributes: []hcl.AttributeSchema{
-		{
-			Name: schema.AttributeTypeTitle,
-		},
-		{
-			Name: schema.AttributeTypeDescription,
-		},
-		{
-			Name: schema.AttributeTypeForEach,
-		},
-		{
-			Name: schema.AttributeTypeDependsOn,
-		},
-		{
-			Name: schema.AttributeTypeIf,
-		},
-		{
-			Name: schema.AttributeTypeText,
-		},
-		{
-			Name: schema.AttributeTypeNumeric,
-		},
-		{
-			Name: schema.AttributeTypeJson,
-		},
-	},
-	Blocks: []hcl.BlockHeaderSchema{
-		{
-			Type: schema.BlockTypeError,
-		},
-		{
-			Type:       schema.BlockTypePipelineOutput,
-			LabelNames: []string{schema.LabelName},
-		},
-		{
-			Type: schema.BlockTypeLoop,
-		},
-		{
-			Type: schema.BlockTypeRetry,
-		},
-		{
-			Type: schema.BlockTypeThrow,
-		},
-	},
-}
-
 var PipelineStepTransformBlockSchema = &hcl.BodySchema{
 	Attributes: []hcl.AttributeSchema{
 		{

--- a/parse/pipeline_decode.go
+++ b/parse/pipeline_decode.go
@@ -578,8 +578,6 @@ func GetPipelineStepBlockSchema(stepType string) *hcl.BodySchema {
 		return modconfig.PipelineStepSleepBlockSchema
 	case schema.BlockTypePipelineStepEmail:
 		return modconfig.PipelineStepEmailBlockSchema
-	case schema.BlockTypePipelineStepEcho:
-		return modconfig.PipelineStepEchoBlockSchema
 	case schema.BlockTypePipelineStepTransform:
 		return modconfig.PipelineStepTransformBlockSchema
 	case schema.BlockTypePipelineStepQuery:

--- a/schema/hcl.go
+++ b/schema/hcl.go
@@ -64,7 +64,6 @@ const (
 	BlockTypePipelineStepHttp      = "http"
 	BlockTypePipelineStepSleep     = "sleep"
 	BlockTypePipelineStepEmail     = "email"
-	BlockTypePipelineStepEcho      = "echo"
 	BlockTypePipelineStepTransform = "transform"
 	BlockTypePipelineStepQuery     = "query"
 	BlockTypePipelineStepExec      = "exec"
@@ -142,11 +141,6 @@ const (
 	AttributeTypeResponseBody     = "response_body"
 	AttributeTypeStatusCode       = "status_code"
 	AttributeTypeStatus           = "status"
-
-	// Used by echo step
-	AttributeTypeText    = "text"
-	AttributeTypeNumeric = "numeric"
-	AttributeTypeJson    = "json"
 
 	// Used byy Pipeline step
 	AttributeTypePipeline = "pipeline"


### PR DESCRIPTION
Now that we've migrated to the `transform` step, remove the `echo` step from `pipe-fittings`.