### PR TITLE
Rename credential block attributes to align the attribute names with Steampipe connection config. Closes #104

### DIFF
--- a/modconfig/flowpipe_credential.go
+++ b/modconfig/flowpipe_credential.go
@@ -560,8 +560,8 @@ type OktaCredential struct {
 
 	Type string `json:"type" cty:"type" hcl:"type,label"`
 
-	APIToken *string `json:"api_token,omitempty" cty:"api_token" hcl:"api_token,optional"`
-	Domain   *string `json:"domain,omitempty" cty:"domain" hcl:"domain,optional"`
+	Token  *string `json:"token,omitempty" cty:"token" hcl:"token,optional"`
+	Domain *string `json:"domain,omitempty" cty:"domain" hcl:"domain,optional"`
 }
 
 func (*OktaCredential) GetCredentialType() string {
@@ -570,8 +570,8 @@ func (*OktaCredential) GetCredentialType() string {
 
 func (c *OktaCredential) getEnv() map[string]cty.Value {
 	env := map[string]cty.Value{}
-	if c.APIToken != nil {
-		env["OKTA_TOKEN"] = cty.StringVal(*c.APIToken)
+	if c.Token != nil {
+		env["OKTA_TOKEN"] = cty.StringVal(*c.Token)
 	}
 	if c.Domain != nil {
 		env["OKTA_ORGURL"] = cty.StringVal(*c.Domain)
@@ -593,7 +593,7 @@ func (c *OktaCredential) CtyValue() (cty.Value, error) {
 
 func (c *OktaCredential) Resolve(ctx context.Context) (Credential, error) {
 
-	if c.APIToken == nil && c.Domain == nil {
+	if c.Token == nil && c.Domain == nil {
 		apiTokenEnvVar := os.Getenv("OKTA_TOKEN")
 		domainEnvVar := os.Getenv("OKTA_ORGURL")
 
@@ -606,9 +606,9 @@ func (c *OktaCredential) Resolve(ctx context.Context) (Credential, error) {
 				DeclRange:       c.DeclRange,
 				blockType:       c.blockType,
 			},
-			Type:     c.Type,
-			APIToken: &apiTokenEnvVar,
-			Domain:   &domainEnvVar,
+			Type:   c.Type,
+			Token:  &apiTokenEnvVar,
+			Domain: &domainEnvVar,
 		}
 
 		return newCreds, nil
@@ -758,7 +758,7 @@ type ClickUpCredential struct {
 
 	Type string `json:"type" cty:"type" hcl:"type,label"`
 
-	APIToken *string `json:"api_token,omitempty" cty:"api_token" hcl:"api_token,optional"`
+	Token *string `json:"token,omitempty" cty:"token" hcl:"token,optional"`
 }
 
 func (*ClickUpCredential) GetCredentialType() string {
@@ -767,8 +767,8 @@ func (*ClickUpCredential) GetCredentialType() string {
 
 func (c *ClickUpCredential) getEnv() map[string]cty.Value {
 	env := map[string]cty.Value{}
-	if c.APIToken != nil {
-		env["CLICKUP_TOKEN"] = cty.StringVal(*c.APIToken)
+	if c.Token != nil {
+		env["CLICKUP_TOKEN"] = cty.StringVal(*c.Token)
 	}
 	return env
 }
@@ -786,7 +786,7 @@ func (c *ClickUpCredential) CtyValue() (cty.Value, error) {
 }
 
 func (c *ClickUpCredential) Resolve(ctx context.Context) (Credential, error) {
-	if c.APIToken == nil {
+	if c.Token == nil {
 		clickUpAPITokenEnvVar := os.Getenv("CLICKUP_TOKEN")
 
 		// Don't modify existing credential, resolve to a new one
@@ -798,8 +798,8 @@ func (c *ClickUpCredential) Resolve(ctx context.Context) (Credential, error) {
 				DeclRange:       c.DeclRange,
 				blockType:       c.blockType,
 			},
-			Type:     c.Type,
-			APIToken: &clickUpAPITokenEnvVar,
+			Type:  c.Type,
+			Token: &clickUpAPITokenEnvVar,
 		}
 
 		return newCreds, nil
@@ -1200,7 +1200,7 @@ type GithubCredential struct {
 
 	Type string `json:"type" cty:"type" hcl:"type,label"`
 
-	AccessToken *string `json:"access_token,omitempty" cty:"access_token" hcl:"access_token,optional"`
+	Token *string `json:"token,omitempty" cty:"token" hcl:"token,optional"`
 }
 
 func (*GithubCredential) GetCredentialType() string {
@@ -1209,8 +1209,8 @@ func (*GithubCredential) GetCredentialType() string {
 
 func (c *GithubCredential) getEnv() map[string]cty.Value {
 	env := map[string]cty.Value{}
-	if c.AccessToken != nil {
-		env["GITHUB_TOKEN"] = cty.StringVal(*c.AccessToken)
+	if c.Token != nil {
+		env["GITHUB_TOKEN"] = cty.StringVal(*c.Token)
 	}
 	return env
 }
@@ -1228,7 +1228,7 @@ func (c *GithubCredential) CtyValue() (cty.Value, error) {
 }
 
 func (c *GithubCredential) Resolve(ctx context.Context) (Credential, error) {
-	if c.AccessToken == nil {
+	if c.Token == nil {
 		githubAccessTokenEnvVar := os.Getenv("GITHUB_TOKEN")
 
 		// Don't modify existing credential, resolve to a new one
@@ -1240,8 +1240,8 @@ func (c *GithubCredential) Resolve(ctx context.Context) (Credential, error) {
 				DeclRange:       c.DeclRange,
 				blockType:       c.blockType,
 			},
-			Type:        c.Type,
-			AccessToken: &githubAccessTokenEnvVar,
+			Type:  c.Type,
+			Token: &githubAccessTokenEnvVar,
 		}
 
 		return newCreds, nil
@@ -1263,7 +1263,7 @@ type GitLabCredential struct {
 
 	Type string `json:"type" cty:"type" hcl:"type,label"`
 
-	AccessToken *string `json:"access_token,omitempty" cty:"access_token" hcl:"access_token,optional"`
+	Token *string `json:"token,omitempty" cty:"token" hcl:"token,optional"`
 }
 
 func (*GitLabCredential) GetCredentialType() string {
@@ -1272,8 +1272,8 @@ func (*GitLabCredential) GetCredentialType() string {
 
 func (c *GitLabCredential) getEnv() map[string]cty.Value {
 	env := map[string]cty.Value{}
-	if c.AccessToken != nil {
-		env["GITLAB_TOKEN"] = cty.StringVal(*c.AccessToken)
+	if c.Token != nil {
+		env["GITLAB_TOKEN"] = cty.StringVal(*c.Token)
 	}
 	return env
 }
@@ -1291,7 +1291,7 @@ func (c *GitLabCredential) CtyValue() (cty.Value, error) {
 }
 
 func (c *GitLabCredential) Resolve(ctx context.Context) (Credential, error) {
-	if c.AccessToken == nil {
+	if c.Token == nil {
 		gitlabAccessTokenEnvVar := os.Getenv("GITLAB_TOKEN")
 
 		// Don't modify existing credential, resolve to a new one
@@ -1303,8 +1303,8 @@ func (c *GitLabCredential) Resolve(ctx context.Context) (Credential, error) {
 				DeclRange:       c.DeclRange,
 				blockType:       c.blockType,
 			},
-			Type:        c.Type,
-			AccessToken: &gitlabAccessTokenEnvVar,
+			Type:  c.Type,
+			Token: &gitlabAccessTokenEnvVar,
 		}
 
 		return newCreds, nil

--- a/modconfig/flowpipe_credential_test.go
+++ b/modconfig/flowpipe_credential_test.go
@@ -178,7 +178,7 @@ func TestOktaDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newOktaCreds := newCreds.(*OktaCredential)
-	assert.Equal("", *newOktaCreds.APIToken)
+	assert.Equal("", *newOktaCreds.Token)
 	assert.Equal("", *newOktaCreds.Domain)
 
 	os.Setenv("OKTA_TOKEN", "00B630jSCGU4jV4o5Yh4KQMAdqizwE2OgVcS7N9UHb")
@@ -188,7 +188,7 @@ func TestOktaDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newOktaCreds = newCreds.(*OktaCredential)
-	assert.Equal("00B630jSCGU4jV4o5Yh4KQMAdqizwE2OgVcS7N9UHb", *newOktaCreds.APIToken)
+	assert.Equal("00B630jSCGU4jV4o5Yh4KQMAdqizwE2OgVcS7N9UHb", *newOktaCreds.Token)
 	assert.Equal("https://dev-50078045.okta.com", *newOktaCreds.Domain)
 }
 
@@ -286,7 +286,7 @@ func TestClickUpDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newClickUpCreds := newCreds.(*ClickUpCredential)
-	assert.Equal("", *newClickUpCreds.APIToken)
+	assert.Equal("", *newClickUpCreds.Token)
 
 	os.Setenv("CLICKUP_TOKEN", "pk_616_L5H36X3CXXXXXXXWEAZZF0NM5")
 
@@ -294,7 +294,7 @@ func TestClickUpDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newClickUpCreds = newCreds.(*ClickUpCredential)
-	assert.Equal("pk_616_L5H36X3CXXXXXXXWEAZZF0NM5", *newClickUpCreds.APIToken)
+	assert.Equal("pk_616_L5H36X3CXXXXXXXWEAZZF0NM5", *newClickUpCreds.Token)
 }
 
 func TestPagerDutyDefaultCredential(t *testing.T) {
@@ -436,7 +436,7 @@ func TestGitHubDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newGithubAccessTokenCreds := newCreds.(*GithubCredential)
-	assert.Equal("", *newGithubAccessTokenCreds.AccessToken)
+	assert.Equal("", *newGithubAccessTokenCreds.Token)
 
 	os.Setenv("GITHUB_TOKEN", "ghpat-ljgllghhegweroyuouo67u5476070owetylh")
 
@@ -444,7 +444,7 @@ func TestGitHubDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newGithubAccessTokenCreds = newCreds.(*GithubCredential)
-	assert.Equal("ghpat-ljgllghhegweroyuouo67u5476070owetylh", *newGithubAccessTokenCreds.AccessToken)
+	assert.Equal("ghpat-ljgllghhegweroyuouo67u5476070owetylh", *newGithubAccessTokenCreds.Token)
 }
 
 func TestGitLabDefaultCredential(t *testing.T) {
@@ -461,7 +461,7 @@ func TestGitLabDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newGitLabAccessTokenCreds := newCreds.(*GitLabCredential)
-	assert.Equal("", *newGitLabAccessTokenCreds.AccessToken)
+	assert.Equal("", *newGitLabAccessTokenCreds.Token)
 
 	os.Setenv("GITLAB_TOKEN", "glpat-ljgllghhegweroyuouo67u5476070owetylh")
 
@@ -469,7 +469,7 @@ func TestGitLabDefaultCredential(t *testing.T) {
 	assert.Nil(err)
 
 	newGitLabAccessTokenCreds = newCreds.(*GitLabCredential)
-	assert.Equal("glpat-ljgllghhegweroyuouo67u5476070owetylh", *newGitLabAccessTokenCreds.AccessToken)
+	assert.Equal("glpat-ljgllghhegweroyuouo67u5476070owetylh", *newGitLabAccessTokenCreds.Token)
 }
 
 func TestPipesDefaultCredential(t *testing.T) {


### PR DESCRIPTION
**Okta**
- Renamed `api_token` to `token`.

**Clickup**
- Renamed `api_token` to `token`.

**GitHub**
- Renamed `access_token` to `token`.

**GitLab**
- Renamed `access_token` to `token`.