### PR TITLE
Add Datadog credential type. Closes #88

### DIFF
--- a/modconfig/flowpipe_credential.go
+++ b/modconfig/flowpipe_credential.go
@@ -1935,15 +1935,11 @@ func (c *DatadogCredential) Resolve(ctx context.Context) (Credential, error) {
 		APIUrl: c.APIUrl,
 	}
 
-	if c.APIKey == nil && datadogAPIKeyEnvVar == "" {
-		return nil, perr.InternalWithMessage("datadog api_key is required")
-	} else if c.APIKey == nil {
+	if c.APIKey == nil {
 		newCreds.APIKey = &datadogAPIKeyEnvVar
 	}
 
-	if c.AppKey == nil && datadogAppKeyEnvVar == "" {
-		return nil, perr.InternalWithMessage("datadog app_key is required")
-	} else if c.AppKey == nil {
+	if c.AppKey == nil {
 		newCreds.AppKey = &datadogAppKeyEnvVar
 	}
 

--- a/modconfig/flowpipe_credential.go
+++ b/modconfig/flowpipe_credential.go
@@ -1937,10 +1937,14 @@ func (c *DatadogCredential) Resolve(ctx context.Context) (Credential, error) {
 
 	if c.APIKey == nil {
 		newCreds.APIKey = &datadogAPIKeyEnvVar
+	} else {
+		newCreds.APIKey = c.APIKey
 	}
 
 	if c.AppKey == nil {
 		newCreds.AppKey = &datadogAppKeyEnvVar
+	} else {
+		newCreds.AppKey = c.AppKey
 	}
 
 	return newCreds, nil

--- a/modconfig/flowpipe_credential_test.go
+++ b/modconfig/flowpipe_credential_test.go
@@ -702,8 +702,11 @@ func TestDatadogDefaultCredential(t *testing.T) {
 	os.Unsetenv("DD_CLIENT_APP_KEY")
 
 	newCreds, err := datadogCred.Resolve(context.TODO())
-	assert.ErrorContains(err, "datadog api_key is required")
-	assert.Nil(newCreds)
+	assert.Nil(err)
+
+	newDatadogCreds := newCreds.(*DatadogCredential)
+	assert.Equal("", *newDatadogCreds.APIKey)
+	assert.Equal("", *newDatadogCreds.AppKey)
 
 	os.Setenv("DD_CLIENT_API_KEY", "b1cf23432fwef23fg24grg31gr")
 	os.Setenv("DD_CLIENT_APP_KEY", "1a2345bc23fwefrg13g233f")
@@ -711,7 +714,7 @@ func TestDatadogDefaultCredential(t *testing.T) {
 	newCreds, err = datadogCred.Resolve(context.TODO())
 	assert.Nil(err)
 
-	newDatadogCreds := newCreds.(*DatadogCredential)
+	newDatadogCreds = newCreds.(*DatadogCredential)
 	assert.Equal("b1cf23432fwef23fg24grg31gr", *newDatadogCreds.APIKey)
 	assert.Equal("1a2345bc23fwefrg13g233f", *newDatadogCreds.AppKey)
 }

--- a/modconfig/flowpipe_credential_test.go
+++ b/modconfig/flowpipe_credential_test.go
@@ -702,11 +702,8 @@ func TestDatadogDefaultCredential(t *testing.T) {
 	os.Unsetenv("DD_CLIENT_APP_KEY")
 
 	newCreds, err := datadogCred.Resolve(context.TODO())
-	assert.Nil(err)
-
-	newDatadogCreds := newCreds.(*DatadogCredential)
-	assert.Equal("", *newDatadogCreds.APIKey)
-	assert.Equal("", *newDatadogCreds.AppKey)
+	assert.EqualError(err, "Internal Error: datadog api_key is required")
+	assert.Nil(newCreds)
 
 	os.Setenv("DD_CLIENT_API_KEY", "b1cf23432fwef23fg24grg31gr")
 	os.Setenv("DD_CLIENT_APP_KEY", "1a2345bc23fwefrg13g233f")
@@ -714,7 +711,7 @@ func TestDatadogDefaultCredential(t *testing.T) {
 	newCreds, err = datadogCred.Resolve(context.TODO())
 	assert.Nil(err)
 
-	newDatadogCreds = newCreds.(*DatadogCredential)
+	newDatadogCreds := newCreds.(*DatadogCredential)
 	assert.Equal("b1cf23432fwef23fg24grg31gr", *newDatadogCreds.APIKey)
 	assert.Equal("1a2345bc23fwefrg13g233f", *newDatadogCreds.AppKey)
 }

--- a/modconfig/flowpipe_credential_test.go
+++ b/modconfig/flowpipe_credential_test.go
@@ -689,6 +689,36 @@ func TestBitbucketDefaultCredential(t *testing.T) {
 	assert.Equal("ksfhashkfhakskashfghaskfagfgir327934gkegf", *newBitbucketCreds.Password)
 }
 
+func TestDatadogDefaultCredential(t *testing.T) {
+	assert := assert.New(t)
+
+	datadogCred := DatadogCredential{
+		HclResourceImpl: HclResourceImpl{
+			ShortName: "default",
+		},
+	}
+
+	os.Unsetenv("DD_CLIENT_API_KEY")
+	os.Unsetenv("DD_CLIENT_APP_KEY")
+
+	newCreds, err := datadogCred.Resolve(context.TODO())
+	assert.Nil(err)
+
+	newDatadogCreds := newCreds.(*DatadogCredential)
+	assert.Equal("", *newDatadogCreds.APIKey)
+	assert.Equal("", *newDatadogCreds.AppKey)
+
+	os.Setenv("DD_CLIENT_API_KEY", "b1cf23432fwef23fg24grg31gr")
+	os.Setenv("DD_CLIENT_APP_KEY", "1a2345bc23fwefrg13g233f")
+
+	newCreds, err = datadogCred.Resolve(context.TODO())
+	assert.Nil(err)
+
+	newDatadogCreds = newCreds.(*DatadogCredential)
+	assert.Equal("b1cf23432fwef23fg24grg31gr", *newDatadogCreds.APIKey)
+	assert.Equal("1a2345bc23fwefrg13g233f", *newDatadogCreds.AppKey)
+}
+
 func XTestAwsCredentialRole(t *testing.T) {
 
 	assert := assert.New(t)

--- a/modconfig/flowpipe_credential_test.go
+++ b/modconfig/flowpipe_credential_test.go
@@ -702,7 +702,7 @@ func TestDatadogDefaultCredential(t *testing.T) {
 	os.Unsetenv("DD_CLIENT_APP_KEY")
 
 	newCreds, err := datadogCred.Resolve(context.TODO())
-	assert.EqualError(err, "Internal Error: datadog api_key is required")
+	assert.ErrorContains(err, "datadog api_key is required")
 	assert.Nil(newCreds)
 
 	os.Setenv("DD_CLIENT_API_KEY", "b1cf23432fwef23fg24grg31gr")


### PR DESCRIPTION
```
Running tool: /opt/homebrew/bin/go test -timeout 30s -run ^TestDatadogDefaultCredential$ github.com/turbot/pipe-fittings/modconfig

ok  	github.com/turbot/pipe-fittings/modconfig	0.456s
```