### PR TITLE
feat(context functions): Add `type` function for dynamic type evaluation. Closes #269

### DIFF
--- a/funcs/context_functions.go
+++ b/funcs/context_functions.go
@@ -122,6 +122,7 @@ func ContextFunctions(baseDir string) map[string]function.Function {
 		"trimspace":        stdlib.TrimSpaceFunc,
 		"trimsuffix":       stdlib.TrimSuffixFunc,
 		"try":              tryfunc.TryFunc,
+		"type":             TypeFunc,
 		"upper":            stdlib.UpperFunc,
 		"urlencode":        funcs.URLEncodeFunc,
 		"uuid":             funcs.UUIDFunc,
@@ -136,4 +137,31 @@ func ContextFunctions(baseDir string) map[string]function.Function {
 	}
 
 	return ctxFuncs
+}
+
+// Custom type function returns the type of the given value
+var TypeFunc = function.New(&function.Spec{
+	Description: `Returns the type of the given value.`,
+	Params: []function.Parameter{
+		{
+			Name:             "value",
+			Type:             cty.DynamicPseudoType,
+			AllowUnknown:     true,
+			AllowDynamicType: true,
+			AllowNull:        true,
+		},
+	},
+	Type: func(args []cty.Value) (cty.Type, error) {
+		return cty.String, nil
+	},
+	Impl: func(args []cty.Value, retType cty.Type) (cty.Value, error) {
+		valueType := args[0].Type()
+		typeName := valueType.FriendlyName()
+
+		return cty.StringVal(typeName), nil
+	},
+})
+
+func Type(input []cty.Value) (cty.Value, error) {
+	return TypeFunc.Call(input)
 }


### PR DESCRIPTION
<details>
  <summary>Pipeline</summary>

```hcl
pipeline "type_func" {
  
  param "string_type" {
    type    = string
    default = "default"
  }

  param "number_type" {
    type    = number
    default = 1
  }

  param "bool_type" {
    type    = bool
    default = false
  }

  param "string_slice_type" {
    type    = set(string)
    default = ["guitar", "bass", "drums"]
  }

  param "number_slice_type" {
    type    = set(number)
    default = [1, 2, 3]
  }

  output "string_type" {
    value = type("Hello World!")
  }
  output "string_type_unresolved" {
    value = type(param.string_type)
  }

  output "number_type" {
    value = type(100)
  }
  output "number_type_unresolved" {
    value = type(param.number_type)
  }

  output "bool_type" {
    value = type(true)
  }
  output "bool_type_unresolved" {
    value = type(param.bool_type)
  }

  output "string_slice_type" {
    value = type(["guitar", "bass", "drums"])
  }
  output "string_slice_type_unresolved" {
    value = type(param.string_slice_type)
  }

  output "number_slice_type" {
    value = type([1, 2, 3])
  }
  output "number_slice_type_unresolved" {
    value = type(param.number_slice_type)
  }
}
```
</details>

<img width="915" alt="Screenshot 2024-02-19 at 10 17 09 AM" src="https://github.com/turbot/pipe-fittings/assets/38218418/e87bcd95-f454-4af2-991e-9f73897f4089">
