### PR TITLE
Update SteampipePGConnection to construct connection string if needed

### DIFF
--- a/connection/connection_test.go
+++ b/connection/connection_test.go
@@ -2,6 +2,7 @@ package connection
 
 import (
 	"context"
+	"github.com/turbot/pipe-fittings/utils"
 	"os"
 	"testing"
 
@@ -867,6 +868,61 @@ func TestDiscordConnectionValidate(t *testing.T) {
 	}
 	diagnostics = conn.Validate()
 	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a populated DiscordConnection")
+}
+
+// ------------------------------------------------------------
+// DuckDb
+// ------------------------------------------------------------
+
+func TestDuckDbConnectionEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Both connections are nil
+	var conn1 *DuckDbConnection
+	var conn2 *DuckDbConnection
+	assert.True(conn1.Equals(conn2), "Both connections should be nil and equal")
+
+	// Case 2: One connection is nil
+	conn1 = &DuckDbConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+	}
+	assert.False(conn1.Equals(nil), "One connection is nil, should return false")
+
+	// Case 3: Both connections have the same connection_string
+	connectionString := "postgres://user:password@localhost:5432/dbname"
+	conn1.ConnectionString = &connectionString
+	conn2 = &DuckDbConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		ConnectionString: &connectionString,
+	}
+
+	assert.True(conn1.Equals(conn2), "Both connections have the same connection_string and should be equal")
+
+	// Case 4: Connections have different connection_strings
+	connectionString2 := "postgres://user:password@localhost:5432/dbname2"
+	conn2.ConnectionString = &connectionString2
+	assert.False(conn1.Equals(conn2), "Connections have different connection_string, should return false")
+
+}
+
+func TestDuckDbConnectionValidate(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Validate an empty DuckDbConnection, should fail with diagnostics
+	conn := &DuckDbConnection{}
+	diagnostics := conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for an empty DuckDbConnection")
+
+	// Case 2: Validate a DuckDbConnection with connection_String should pass with no diagnostics
+	conn = &DuckDbConnection{
+		ConnectionString: utils.ToStringPointer("postgres://user:password@localhost:5432/dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a DuckDbConnection with connection_string")
 }
 
 // ------------------------------------------------------------
@@ -2168,6 +2224,61 @@ func TestPagerDutyConnectionValidate(t *testing.T) {
 }
 
 // ------------------------------------------------------------
+// Postgres
+// ------------------------------------------------------------
+
+func TestPostgresConnectionEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Both connections are nil
+	var conn1 *PostgresConnection
+	var conn2 *PostgresConnection
+	assert.True(conn1.Equals(conn2), "Both connections should be nil and equal")
+
+	// Case 2: One connection is nil
+	conn1 = &PostgresConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+	}
+	assert.False(conn1.Equals(nil), "One connection is nil, should return false")
+
+	// Case 3: Both connections have the same connection_string
+	connectionString := "postgres://user:password@localhost:5432/dbname"
+	conn1.ConnectionString = &connectionString
+	conn2 = &PostgresConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		ConnectionString: &connectionString,
+	}
+
+	assert.True(conn1.Equals(conn2), "Both connections have the same connection_string and should be equal")
+
+	// Case 4: Connections have different connection_strings
+	connectionString2 := "postgres://user:password@localhost:5432/dbname2"
+	conn2.ConnectionString = &connectionString2
+	assert.False(conn1.Equals(conn2), "Connections have different connection_string, should return false")
+
+}
+
+func TestPostgresConnectionValidate(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Validate an empty PostgresConnection, should fail with diagnostics
+	conn := &PostgresConnection{}
+	diagnostics := conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for an empty PostgresConnection")
+
+	// Case 2: Validate a PostgresConnection with connection_String should pass with no diagnostics
+	conn = &PostgresConnection{
+		ConnectionString: utils.ToStringPointer("postgres://user:password@localhost:5432/dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a PostgresConnection with connection_string")
+}
+
+// ------------------------------------------------------------
 // SendGrid
 // ------------------------------------------------------------
 
@@ -2468,6 +2579,130 @@ func TestSlackConnectionValidate(t *testing.T) {
 	}
 	diagnostics = conn.Validate()
 	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a populated SlackConnection")
+}
+
+// ------------------------------------------------------------
+// SteampipePg
+// ------------------------------------------------------------
+
+func TestSteampipePgConnectionEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Both connections are nil
+	var conn1 *SteampipePgConnection
+	var conn2 *SteampipePgConnection
+	assert.True(conn1.Equals(conn2), "Both connections should be nil and equal")
+
+	// Case 2: One connection is nil
+	conn1 = &SteampipePgConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+	}
+	assert.False(conn1.Equals(nil), "One connection is nil, should return false")
+	// Case 3: Both connections have the same connection_string
+	connectionString := "postgres://user:password@localhost:5432/dbname"
+	conn1.ConnectionString = &connectionString
+	conn2 = &SteampipePgConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		ConnectionString: &connectionString,
+	}
+
+	assert.True(conn1.Equals(conn2), "Both connections have the same connection_string and should be equal")
+
+	// Case 4: Connections have different connection_strings
+	connectionString2 := "postgres://user:password@localhost:5432/dbname2"
+	conn2.ConnectionString = &connectionString2
+	assert.False(conn1.Equals(conn2), "Connections have different connection_string, should return false")
+
+	//Case 5: Connections have same settings
+	conn1 = &SteampipePgConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		UserName: utils.ToStringPointer("user"),
+		Password: utils.ToStringPointer("password"),
+		Host:     utils.ToStringPointer("localhost"),
+		Port:     utils.ToIntegerPointer(5432),
+		DbName:   utils.ToStringPointer("dbname"),
+	}
+	conn2 = &SteampipePgConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		UserName: utils.ToStringPointer("user"),
+		Password: utils.ToStringPointer("password"),
+		Host:     utils.ToStringPointer("localhost"),
+		Port:     utils.ToIntegerPointer(5432),
+		DbName:   utils.ToStringPointer("dbname"),
+	}
+
+	assert.True(conn1.Equals(conn2), "Both connections have the same settings and should be equal")
+
+	//Case 6: Connections have different settings
+
+	conn2.UserName = utils.ToStringPointer("user2")
+	assert.False(conn1.Equals(conn2), "Both connections have the different user_name and should not be equal")
+
+	// Case 7: Connection 2 is a subset of Connection 1
+	conn2 = &SteampipePgConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		UserName: utils.ToStringPointer("user"),
+		Password: utils.ToStringPointer("password"),
+		DbName:   utils.ToStringPointer("dbname"),
+	}
+	assert.False(conn1.Equals(conn2), "Connection 2 is a subset of Connection 1, should return false")
+}
+
+func TestSteampipePgConnectionValidate(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Validate an empty SteampipePgConnection, should fail with diagnostics
+	conn := &SteampipePgConnection{}
+	diagnostics := conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for an empty SteampipePgConnection")
+
+	// Case 2: Validate a SteampipePgConnection with connection_String should pass with no diagnostics
+	conn = &SteampipePgConnection{
+		ConnectionString: utils.ToStringPointer("postgres://user:password@localhost:5432/dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a SteampipePgConnection with connection_string")
+
+	// Case 2: Validate a SteampipePgConnection with user name and db should pass with no diagnostics
+	conn = &SteampipePgConnection{
+		UserName: utils.ToStringPointer("user"),
+		DbName:   utils.ToStringPointer("dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a SteampipePgConnection with user name and db")
+
+	// Case 3: Validate a SteampipePgConnection with connectrion string AND user name and db, should fail with diagnostics
+	conn = &SteampipePgConnection{
+		ConnectionString: utils.ToStringPointer("postgres://user:password@localhost:5432/dbname"),
+		UserName:         utils.ToStringPointer("user"),
+		DbName:           utils.ToStringPointer("dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for a SteampipePgConnection with connection_string and user name and db")
+
+	// Case 4: Validate a SteampipePgConnection with user name but no db, should fail with diagnostics
+	conn = &SteampipePgConnection{
+		UserName: utils.ToStringPointer("user"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for a SteampipePgConnection with user name but no db")
+
+	// Case 5: Validate a SteampipePgConnection with db name but no user, should fail with diagnostics
+	conn = &SteampipePgConnection{
+		DbName: utils.ToStringPointer("dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for a SteampipePgConnection with db name but no user")
 }
 
 // ------------------------------------------------------------
@@ -2777,6 +3012,61 @@ func TestPipesConnectionValidate(t *testing.T) {
 	}
 	diagnostics = conn.Validate()
 	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a populated PipesConnection")
+}
+
+// ------------------------------------------------------------
+// Sqlite
+// ------------------------------------------------------------
+
+func TestSqliteConnectionEquals(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Both connections are nil
+	var conn1 *SqliteConnection
+	var conn2 *SqliteConnection
+	assert.True(conn1.Equals(conn2), "Both connections should be nil and equal")
+
+	// Case 2: One connection is nil
+	conn1 = &SqliteConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+	}
+	assert.False(conn1.Equals(nil), "One connection is nil, should return false")
+
+	// Case 3: Both connections have the same connection_string
+	connectionString := "postgres://user:password@localhost:5432/dbname"
+	conn1.ConnectionString = &connectionString
+	conn2 = &SqliteConnection{
+		ConnectionImpl: ConnectionImpl{
+			ShortName: "default",
+		},
+		ConnectionString: &connectionString,
+	}
+
+	assert.True(conn1.Equals(conn2), "Both connections have the same connection_string and should be equal")
+
+	// Case 4: Connections have different connection_strings
+	connectionString2 := "postgres://user:password@localhost:5432/dbname2"
+	conn2.ConnectionString = &connectionString2
+	assert.False(conn1.Equals(conn2), "Connections have different connection_string, should return false")
+
+}
+
+func TestSqliteConnectionValidate(t *testing.T) {
+	assert := assert.New(t)
+
+	// Case 1: Validate an empty SqliteConnection, should fail with diagnostics
+	conn := &SqliteConnection{}
+	diagnostics := conn.Validate()
+	assert.Len(diagnostics, 1, "Validation should fail with 1 diagnostics for an empty SqliteConnection")
+
+	// Case 2: Validate a SqliteConnection with connection_String should pass with no diagnostics
+	conn = &SqliteConnection{
+		ConnectionString: utils.ToStringPointer("postgres://user:password@localhost:5432/dbname"),
+	}
+	diagnostics = conn.Validate()
+	assert.Len(diagnostics, 0, "Validation should pass with no diagnostics for a SqliteConnection with connection_string")
 }
 
 // ------------------------------------------------------------

--- a/connection/duckdb.go
+++ b/connection/duckdb.go
@@ -13,7 +13,7 @@ const DuckDbConnectionType = "duckdb"
 
 type DuckDbConnection struct {
 	ConnectionImpl
-	ConnectionString *string `json:"database,omitempty" cty:"database" hcl:"database,optional"`
+	ConnectionString *string `json:"connection_string,omitempty" cty:"connection_string" hcl:"connection_string,optional"`
 }
 
 func NewDuckDbConnection(shortName string, declRange hcl.Range) PipelingConnection {

--- a/connection/guardrails.go
+++ b/connection/guardrails.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-const GuardrailsConnectionType = "turbot_guardrails"
+const GuardrailsConnectionType = "guardrails"
 
 type GuardrailsConnection struct {
 	ConnectionImpl

--- a/connection/pipes.go
+++ b/connection/pipes.go
@@ -10,7 +10,7 @@ import (
 	"github.com/zclconf/go-cty/cty"
 )
 
-const PipesConnectionType = "turbot_pipes"
+const PipesConnectionType = "pipes"
 
 type PipesConnection struct {
 	ConnectionImpl

--- a/connection/sqllite.go
+++ b/connection/sqllite.go
@@ -13,7 +13,7 @@ const SqliteConnectionType = "Sqlite"
 
 type SqliteConnection struct {
 	ConnectionImpl
-	ConnectionString *string `json:"database,omitempty" cty:"database" hcl:"database,optional"`
+	ConnectionString *string `json:"connection_string,omitempty" cty:"connection_string" hcl:"connection_string,optional"`
 }
 
 func NewSqliteConnection(shortName string, declRange hcl.Range) PipelingConnection {

--- a/connection/steampipe_pg.go
+++ b/connection/steampipe_pg.go
@@ -2,10 +2,13 @@ package connection
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/turbot/go-kit/helpers"
+	typehelpers "github.com/turbot/go-kit/types"
 	"github.com/turbot/pipe-fittings/utils"
 	"github.com/zclconf/go-cty/cty"
+	"net/url"
 )
 
 const SteampipePgConnectionType = "steampipe_pg"
@@ -13,11 +16,13 @@ const SteampipePgConnectionType = "steampipe_pg"
 type SteampipePgConnection struct {
 	ConnectionImpl
 	ConnectionString *string `json:"connection_string,omitempty" cty:"connection_string" hcl:"connection_string,optional"`
+	DbName           *string `json:"db,omitempty" cty:"db" hcl:"db,optional"`
 	UserName         *string `json:"username,omitempty" cty:"username" hcl:"username,optional"`
 	Host             *string `json:"host,omitempty" cty:"host" hcl:"host,optional"`
 	Port             *int    `json:"port,omitempty" cty:"port" hcl:"port,optional"`
 	Password         *string `json:"password,omitempty" cty:"password" hcl:"password,optional"`
 	SearchPath       *string `json:"search_path,omitempty" cty:"search_path" hcl:"search_path,optional"`
+	SslMode          *string `json:"sslmode,omitempty" cty:"sslmode" hcl:"sslmode,optional"`
 }
 
 func NewSteampipePgConnection(shortName string, declRange hcl.Range) PipelingConnection {
@@ -40,7 +45,8 @@ func (c *SteampipePgConnection) Resolve(ctx context.Context) (PipelingConnection
 }
 
 func (c *SteampipePgConnection) Validate() hcl.Diagnostics {
-	if c.Pipes != nil && (c.ConnectionString != nil) {
+	// if pipes metadata is set, no other properties should be sets
+	if c.Pipes != nil && (c.ConnectionString != nil || c.UserName != nil || c.Host != nil || c.Port != nil || c.Password != nil || c.SearchPath != nil) {
 		return hcl.Diagnostics{
 			{
 				Severity: hcl.DiagError,
@@ -49,24 +55,81 @@ func (c *SteampipePgConnection) Validate() hcl.Diagnostics {
 			},
 		}
 	}
-	if c.Pipes == nil && c.ConnectionString == nil {
-		return hcl.Diagnostics{
-			{
-				Severity: hcl.DiagError,
-				Summary:  "either pipes block or connection_string should be set",
-				Subject:  c.DeclRange.HclRangePointer(),
-			},
+	// if pipes is not set, either connection_string or user AND db must be set
+	if c.ConnectionString == nil {
+		if c.UserName == nil || c.DbName == nil {
+			return hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "either connection_string or username AND db must be set",
+					Subject:  c.DeclRange.HclRangePointer(),
+				},
+			}
+		}
+	} else {
+		// so connection string is set, user and db should not be set
+		if c.UserName != nil || c.DbName != nil {
+			return hcl.Diagnostics{
+				{
+					Severity: hcl.DiagError,
+					Summary:  "cannot set both connection_string and username/db",
+					Subject:  c.DeclRange.HclRangePointer(),
+				},
+			}
 		}
 	}
-	return hcl.Diagnostics{}
+	return nil
+
 }
 
 func (c *SteampipePgConnection) GetConnectionString() string {
 	if c.ConnectionString != nil {
 		return *c.ConnectionString
 	}
-	// TODO build connection string
-	panic("not implemented")
+
+	// we know that username and db are set
+	user := typehelpers.SafeString(c.UserName)
+	db := typehelpers.SafeString(c.DbName)
+	var host, password string
+	var port int
+	if c.Host != nil {
+		host = *c.Host
+	} else {
+		host = "localhost"
+	}
+	if c.Port != nil {
+		port = *c.Port
+	} else {
+		port = 5432
+	}
+	if c.Password != nil {
+		password = *c.Password
+	}
+	sslmode := typehelpers.SafeString(c.SslMode)
+
+	// Use url.URL to encode the connection string parameters safely
+	connStr := url.URL{
+		Scheme: "postgresql",
+		Host:   fmt.Sprintf("%s:%d", host, port),
+		Path:   db, // This adds the /dbname part in the connection string
+	}
+
+	// Set the user with or without the password
+	if password == "" {
+		connStr.User = url.User(user) // No password
+	} else {
+		connStr.User = url.UserPassword(user, password)
+	}
+
+	// Add SSL mode or other query parameters if needed
+	q := connStr.Query()
+	if sslmode != "" {
+		q.Add("sslmode", sslmode)
+	}
+	connStr.RawQuery = q.Encode()
+
+	return connStr.String()
+
 }
 
 func (c *SteampipePgConnection) GetEnv() map[string]cty.Value {

--- a/connection/steampipe_pg_test.go
+++ b/connection/steampipe_pg_test.go
@@ -1,0 +1,103 @@
+package connection
+
+import (
+	"github.com/stretchr/testify/assert"
+	"github.com/turbot/pipe-fittings/utils"
+	"testing"
+)
+
+func TestSteampipePgConnection_GetConnectionString(t *testing.T) {
+	type fields struct {
+		ConnectionImpl   ConnectionImpl
+		ConnectionString *string
+		DbName           *string
+		UserName         *string
+		Host             *string
+		Port             *int
+		Password         *string
+		SearchPath       *string
+		SslMode          *string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "connection string",
+			fields: fields{
+				ConnectionString: utils.ToStringPointer("postgresql://u1@localhost/db1"),
+			},
+			want: "postgresql://u1@localhost/db1",
+		},
+		{
+			name: "defaults",
+			fields: fields{
+				ConnectionString: nil,
+				UserName:         utils.ToStringPointer("user"),
+				DbName:           utils.ToStringPointer("db"),
+			},
+			want: "postgresql://user@localhost:5432/db",
+		},
+		{
+			name: "host and port",
+			fields: fields{
+				ConnectionString: nil,
+				UserName:         utils.ToStringPointer("user"),
+				DbName:           utils.ToStringPointer("db"),
+				Host:             utils.ToStringPointer("host"),
+				Port:             utils.ToIntegerPointer(1234),
+			},
+			want: "postgresql://user@host:1234/db",
+		},
+		{
+			name: "password",
+			fields: fields{
+				ConnectionString: nil,
+				UserName:         utils.ToStringPointer("user"),
+				DbName:           utils.ToStringPointer("db"),
+				Password:         utils.ToStringPointer("password"),
+			},
+			want: "postgresql://user:password@localhost:5432/db",
+		},
+		{
+			name: "sslmode",
+			fields: fields{
+				ConnectionString: nil,
+				UserName:         utils.ToStringPointer("user"),
+				DbName:           utils.ToStringPointer("db"),
+				SslMode:          utils.ToStringPointer("require"),
+			},
+			want: "postgresql://user@localhost:5432/db?sslmode=require",
+		},
+		{
+			name: "all fields",
+			fields: fields{
+				UserName: utils.ToStringPointer("user"),
+				DbName:   utils.ToStringPointer("db"),
+				Host:     utils.ToStringPointer("host"),
+				Port:     utils.ToIntegerPointer(1234),
+				Password: utils.ToStringPointer("password"),
+				SslMode:  utils.ToStringPointer("require"),
+			},
+			want: "postgresql://user:password@host:1234/db?sslmode=require",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &SteampipePgConnection{
+				ConnectionImpl:   tt.fields.ConnectionImpl,
+				ConnectionString: tt.fields.ConnectionString,
+				DbName:           tt.fields.DbName,
+				UserName:         tt.fields.UserName,
+				Host:             tt.fields.Host,
+				Port:             tt.fields.Port,
+				Password:         tt.fields.Password,
+				SearchPath:       tt.fields.SearchPath,
+				SslMode:          tt.fields.SslMode,
+			}
+			assert.Equalf(t, tt.want, c.GetConnectionString(), "GetConnectionString()")
+		})
+	}
+}


### PR DESCRIPTION
Update typename of Guardrails and Pipes connections to remove 'turbot_' prefix
Add connection tests for SteampipePgConnection, DuckDbConnection, SqliteConnection and PostgresConnection 