### PR TITLE
fix: report configuration file loading failure as warning to avoid shutting down FDW

### DIFF
--- a/parse/parser.go
+++ b/parse/parser.go
@@ -25,7 +25,7 @@ func LoadFileData(paths ...string) (map[string][]byte, hcl.Diagnostics) {
 
 		if err != nil {
 			diags = append(diags, &hcl.Diagnostic{
-				Severity: hcl.DiagError,
+				Severity: hcl.DiagWarning,
 				Summary:  fmt.Sprintf("failed to read config file %s", configPath),
 				Detail:   err.Error()})
 			continue


### PR DESCRIPTION
Just like https://github.com/turbot/steampipe/pull/4233, this PR resolves issues when connection configurations are created dynamically concurrently to executing queries.

Without this PR, the following errors would occur and terminate the FDW process, breaking all concurrent requests targeting other connections:
```
# grep "Internal Error: Failed to load all config files" .steampipe/logs/database-2024-12-18.log
2024-12-18 09:26:31.371 UTC [INFO]  hub: ERROR ErrorAndWarnings err="Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_012345678901.spc: open /builds/myproject/.steampipe/config/aws_012345678901.spc: no such file or directory" warnings=[]
2024-12-18 09:26:31.371 UTC [WARN]  hub: LoadConnectionConfig failed {Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_012345678901.spc: open /builds/myproject/.steampipe/config/aws_012345678901.spc: no such file or directory []}
panic: Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_012345678901.spc: open /builds/myproject/.steampipe/config/aws_012345678901.spc: no such file or directory
2024-12-18 09:29:01.157 UTC [INFO]  hub: ERROR ErrorAndWarnings err="Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_123456789012.spc: open /builds/myproject/.steampipe/config/aws_123456789012.spc: no such file or directory" warnings=[]
2024-12-18 09:29:01.157 UTC [WARN]  hub: LoadConnectionConfig failed {Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_123456789012.spc: open /builds/myproject/.steampipe/config/aws_123456789012.spc: no such file or directory []}
2024-12-18 09:29:01.157 UTC [ERROR] hub: LoadConnectionConfig failed Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_123456789012.spc: open /builds/myproject/.steampipe/config/aws_123456789012.spc: no such file or directory
2024-12-18 09:29:01.158 UTC [4933] WARNING:  lenient_select_setof_jsonb failed to execute query: Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_123456789012.spc: open /builds/myproject/.steampipe/config/aws_123456789012.spc: no such file or directory
2024-12-18 09:29:49.665 UTC [INFO]  hub: ERROR ErrorAndWarnings err="Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_234567890123.spc: open /builds/myproject/.steampipe/config/aws_234567890123.spc: no such file or directory" warnings=[]
2024-12-18 09:29:49.665 UTC [WARN]  hub: LoadConnectionConfig failed {Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_234567890123.spc: open /builds/myproject/.steampipe/config/aws_234567890123.spc: no such file or directory []}
2024-12-18 09:29:49.665 UTC [ERROR] hub: LoadConnectionConfig failed Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_234567890123.spc: open /builds/myproject/.steampipe/config/aws_234567890123.spc: no such file or directory
2024-12-18 09:29:49.665 UTC [5808] ERROR:  Internal Error: Failed to load all config files: failed to read config file /builds/myproject/.steampipe/config/aws_234567890123.spc: open /builds/myproject/.steampipe/config/aws_234567890123.spc: no such file or directory

```

