### PR TITLE
Add AppSpecificParseResourceNameFunc to provide a mechanism to override the resource name parser used by DecodeHclBody - set by Tailpipe to use its own ParsedResourceName type

### DIFF
--- a/modconfig/interfaces.go
+++ b/modconfig/interfaces.go
@@ -77,7 +77,7 @@ type ResourceWithMetadata interface {
 type ModResources interface {
 	WalkResources(resourceFunc func(item HclResource) (bool, error)) error
 	AddResource(item HclResource) hcl.Diagnostics
-	GetResource(parsedName *ParsedResourceName) (resource HclResource, found bool)
+	GetResource(parsedName ResourceNameProvider) (resource HclResource, found bool)
 	Equals(other ModResources) bool
 	AddReference(ref *ResourceReference)
 	GetReferences() map[string]*ResourceReference
@@ -89,9 +89,13 @@ type ModResources interface {
 
 type ModResourcesProvider interface {
 	GetModResources() ModResources
-	GetResource(parsedName *ParsedResourceName) (resource HclResource, found bool)
+	GetResource(parsedName ResourceNameProvider) (resource HclResource, found bool)
 }
 
 type ResourceProvider interface {
-	GetResource(parsedName *ParsedResourceName) (resource HclResource, found bool)
+	GetResource(parsedName ResourceNameProvider) (resource HclResource, found bool)
+}
+
+type ResourceNameProvider interface {
+	ToResourceName() string
 }

--- a/modconfig/mod.go
+++ b/modconfig/mod.go
@@ -209,7 +209,7 @@ func (m *Mod) SetModResources(modResources ModResources) {
 	m.Resources = modResources
 }
 
-func (m *Mod) GetResource(parsedName *ParsedResourceName) (resource HclResource, found bool) {
+func (m *Mod) GetResource(parsedName ResourceNameProvider) (resource HclResource, found bool) {
 	return m.Resources.GetResource(parsedName)
 }
 

--- a/modconfig/resource_dependency.go
+++ b/modconfig/resource_dependency.go
@@ -49,30 +49,3 @@ func isRunTimeDependencyProperty(propertyPath *ParsedPropertyPath) bool {
 	}
 	return false
 }
-
-// getPropertiesFromContent finds any attributes in the given content which depend on this dependency
-//
-//nolint:unused // TODO: unused function
-func (d *ResourceDependency) getPropertiesFromContent(content *hcl.BodyContent) []string {
-	var res []string
-	for _, a := range content.Attributes {
-		vars := a.Expr.Variables()
-		if len(d.Traversals) != len(vars) {
-			break
-		}
-		// build map of paths
-		var traversalMap = make(map[string]bool, len(vars))
-		for _, t := range vars {
-			traversalMap[hclhelpers.TraversalAsString(t)] = true
-		}
-		for _, t := range d.Traversals {
-			if !traversalMap[hclhelpers.TraversalAsString(t)] {
-				return res
-			}
-		}
-
-		// ok so traversals match!
-		res = append(res, a.Name)
-	}
-	return res
-}

--- a/parse/app_specific.go
+++ b/parse/app_specific.go
@@ -11,8 +11,8 @@ var ModDecoderFunc func(...DecoderOption) Decoder
 
 var AppSpecificGetResourceSchemaFunc func(resource modconfig.HclResource, bodySchema *hcl.BodySchema) *hcl.BodySchema
 
-// ParseResourceName provides a mechanism to override the resource name parser used by DecodeHclBody
+// AppSpecificParseResourceNameFunc provides a mechanism to override the resource name parser used by DecodeHclBody
 // it is set by Tailpipe to use its own ParsedResourceName type
-var ParseResourceName = func(propertyPath string) (modconfig.ResourceNameProvider, error) {
+var AppSpecificParseResourceNameFunc = func(propertyPath string) (modconfig.ResourceNameProvider, error) {
 	return modconfig.ParseResourceName(propertyPath)
 }

--- a/parse/app_specific.go
+++ b/parse/app_specific.go
@@ -10,3 +10,10 @@ import (
 var ModDecoderFunc func(...DecoderOption) Decoder
 
 var AppSpecificGetResourceSchemaFunc func(resource modconfig.HclResource, bodySchema *hcl.BodySchema) *hcl.BodySchema
+
+// ParseResourceName provides a mechanism to override the resource name parser used by DecodeHclBody
+// it is set by Tailpipe to use its own ParsedResourceName type
+// TODO extend ResourceNameProvider to allow replacement of modconfig.ParseResourceName throughout the parse package
+var ParseResourceName = func(propertyPath string) (modconfig.ResourceNameProvider, error) {
+	return modconfig.ParseResourceName(propertyPath)
+}

--- a/parse/app_specific.go
+++ b/parse/app_specific.go
@@ -13,7 +13,6 @@ var AppSpecificGetResourceSchemaFunc func(resource modconfig.HclResource, bodySc
 
 // ParseResourceName provides a mechanism to override the resource name parser used by DecodeHclBody
 // it is set by Tailpipe to use its own ParsedResourceName type
-// TODO extend ResourceNameProvider to allow replacement of modconfig.ParseResourceName throughout the parse package
 var ParseResourceName = func(propertyPath string) (modconfig.ResourceNameProvider, error) {
 	return modconfig.ParseResourceName(propertyPath)
 }

--- a/parse/decode_body.go
+++ b/parse/decode_body.go
@@ -119,10 +119,11 @@ func resolveReferences(body hcl.Body, modResourcesProvider modconfig.ResourcePro
 					if scopeTraversal, ok := hclVal.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
 						path := hclhelpers.TraversalAsString(scopeTraversal.Traversal)
 						// parse the resource name - using the app specific parser
-						// (ParseResourceName is a package global variable which defaults to modconfig.ParseResourceName
+						// (AppSpecificParseResourceNameFunc is a package global variable which defaults to modconfig.AppSpecificParseResourceNameFunc
 						// but is overridden by tailpipe so that when Tailpipe calls DecodeHclBody it uses
 						// it's own implementation of ParsedResourceName, which does not expect a mod name)
-						if parsedName, err := ParseResourceName(path); err == nil {
+						parseResourceName := AppSpecificParseResourceNameFunc
+						if parsedName, err := parseResourceName(path); err == nil {
 							if r, ok := modResourcesProvider.GetResource(parsedName); ok {
 								f := rv.FieldByName(field.Name)
 								if f.IsValid() && f.CanSet() {

--- a/parse/decode_body.go
+++ b/parse/decode_body.go
@@ -118,7 +118,8 @@ func resolveReferences(body hcl.Body, modResourcesProvider modconfig.ResourcePro
 				if hclVal, ok := attributes[hclAttribute]; ok {
 					if scopeTraversal, ok := hclVal.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
 						path := hclhelpers.TraversalAsString(scopeTraversal.Traversal)
-						if parsedName, err := modconfig.ParseResourceName(path); err == nil {
+						// parse the resource name - using the app specific parser
+						if parsedName, err := ParseResourceName(path); err == nil {
 							if r, ok := modResourcesProvider.GetResource(parsedName); ok {
 								f := rv.FieldByName(field.Name)
 								if f.IsValid() && f.CanSet() {

--- a/parse/decode_body.go
+++ b/parse/decode_body.go
@@ -119,6 +119,9 @@ func resolveReferences(body hcl.Body, modResourcesProvider modconfig.ResourcePro
 					if scopeTraversal, ok := hclVal.Expr.(*hclsyntax.ScopeTraversalExpr); ok {
 						path := hclhelpers.TraversalAsString(scopeTraversal.Traversal)
 						// parse the resource name - using the app specific parser
+						// (ParseResourceName is a package global variable which defaults to modconfig.ParseResourceName
+						// but is overridden by tailpipe so that when Tailpipe calls DecodeHclBody it uses
+						// it's own implementation of ParsedResourceName, which does not expect a mod name)
 						if parsedName, err := ParseResourceName(path); err == nil {
 							if r, ok := modResourcesProvider.GetResource(parsedName); ok {
 								f := rv.FieldByName(field.Name)

--- a/parse/mod_parse_context.go
+++ b/parse/mod_parse_context.go
@@ -439,7 +439,7 @@ func (m *ModParseContext) setModResources() {
 	m.modResources = modconfig.NewModResources(m.CurrentMod, sourceModResources...)
 }
 
-func (m *ModParseContext) GetResource(parsedName *modconfig.ParsedResourceName) (resource modconfig.HclResource, found bool) {
+func (m *ModParseContext) GetResource(parsedName modconfig.ResourceNameProvider) (resource modconfig.HclResource, found bool) {
 	return m.GetModResources().GetResource(parsedName)
 }
 

--- a/plugin/exists.go
+++ b/plugin/exists.go
@@ -2,21 +2,21 @@ package plugin
 
 import (
 	"context"
-
 	"github.com/turbot/pipe-fittings/v2/ociinstaller"
 	"github.com/turbot/pipe-fittings/v2/versionfile"
 )
 
-// Exists looks up the version file and reports whether a plugin is already installed
-func Exists(ctx context.Context, plugin string) (bool, error) {
+// ExistsInVersionFile looks up the version file and reports whether a plugin is already installed
+func ExistsInVersionFile(ctx context.Context, plugin string) (bool, error) {
 	versionData, err := versionfile.LoadPluginVersionFile(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	imageRef := ociinstaller.NewImageRef(plugin)
+	imageRef := ociinstaller.NewImageRef(plugin).DisplayImageRef()
 
 	// lookup in the version data
-	_, found := versionData.Plugins[imageRef.DisplayImageRef()]
+	_, found := versionData.Plugins[imageRef]
+
 	return found, nil
 }

--- a/plugin/exists.go
+++ b/plugin/exists.go
@@ -2,21 +2,21 @@ package plugin
 
 import (
 	"context"
+
 	"github.com/turbot/pipe-fittings/v2/ociinstaller"
 	"github.com/turbot/pipe-fittings/v2/versionfile"
 )
 
-// ExistsInVersionFile looks up the version file and reports whether a plugin is already installed
-func ExistsInVersionFile(ctx context.Context, plugin string) (bool, error) {
+// Exists looks up the version file and reports whether a plugin is already installed
+func Exists(ctx context.Context, plugin string) (bool, error) {
 	versionData, err := versionfile.LoadPluginVersionFile(ctx)
 	if err != nil {
 		return false, err
 	}
 
-	imageRef := ociinstaller.NewImageRef(plugin).DisplayImageRef()
+	imageRef := ociinstaller.NewImageRef(plugin)
 
 	// lookup in the version data
-	_, found := versionData.Plugins[imageRef]
-
+	_, found := versionData.Plugins[imageRef.DisplayImageRef()]
 	return found, nil
 }

--- a/workspace/workspace.go
+++ b/workspace/workspace.go
@@ -378,6 +378,6 @@ func (w *Workspace) GetModResources() modconfig.ModResources {
 	return w.Mod.GetModResources()
 }
 
-func (w *Workspace) GetResource(parsedName *modconfig.ParsedResourceName) (resource modconfig.HclResource, found bool) {
+func (w *Workspace) GetResource(parsedName modconfig.ResourceNameProvider) (resource modconfig.HclResource, found bool) {
 	return w.GetModResources().GetResource(parsedName)
 }


### PR DESCRIPTION
Add ResourceNameProvider interface to abstract away ParsedResourceName
Update ModResources, ModResourcesProvider and ResourceProvider - GetResource now accepts ResourceNameProvider
Add app_specific. AppSpecificParseResourceNameFunc to allow Tailpipe to use its own ParsedResourceName for DecodeHclBody