### PR TITLE
reinstate legacy grok auto escaping - but display warning if a property needs to be escaped

### DIFF
--- a/app_specific/m.go
+++ b/app_specific/m.go
@@ -1,1 +1,0 @@
-package app_specific

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -109,8 +109,7 @@ func applyDisableTemplateForProperties(fileData []byte, filePath string, config 
 	if string(updatedFileData) != string(fileData) {
 		diags = append(diags, &hcl.Diagnostic{
 			Severity: hcl.DiagWarning,
-			Summary:  "File layout containing '${' should be wrapped in backticks",
-			Detail:   fmt.Sprintf("The file %q contains a file layout property which is not wrapped in backticks. This has been escaped for you, however this will be deprecated in a future version. Please use backticks to escape the property.", filePath),
+			Summary:  fmt.Sprintf("The file %q contains a file_layout property containing hcl reserved characters. This has been auto-escaped for you, but future versions will not do this. Please use backticks to escape the property: file_layout = `${val}`.", filePath),
 		})
 	}
 	fileData = updatedFileData

--- a/parse/parser.go
+++ b/parse/parser.go
@@ -65,20 +65,20 @@ func ParseHclFiles(fileDataMap map[string][]byte, opts ...ParseHclOpt) (hcl.Body
 		default:
 			fileData := fileDataMap[filePath]
 
-			// handle deprecated disableTemplateForProperties
-			//if len(config.disableTemplateForProperties) > 0 {
-			//	fileData, moreDiags = applyDisableTemplateForProperties(fileData, filePath, config, diags)
-			//	diags = append(diags, moreDiags...)
-			//	if diags.HasErrors() {
-			//		continue
-			//	}
-			//}
-
 			// check for grok function calls - execute these to escape grok expressions
 			if config.escapeBackticks {
 				fileData, moreDiags = EscapeBackticks(fileDataMap[filePath], filePath)
 				if moreDiags.HasErrors() {
 					diags = append(diags, moreDiags...)
+					continue
+				}
+			}
+
+			// handle deprecated disableTemplateForProperties
+			if len(config.disableTemplateForProperties) > 0 {
+				fileData, moreDiags = applyDisableTemplateForProperties(fileData, filePath, config, diags)
+				diags = append(diags, moreDiags...)
+				if diags.HasErrors() {
 					continue
 				}
 			}
@@ -98,24 +98,24 @@ func ParseHclFiles(fileDataMap map[string][]byte, opts ...ParseHclOpt) (hcl.Body
 	return hcl.MergeFiles(parsedConfigFiles), diags
 }
 
-//func applyDisableTemplateForProperties(fileData []byte, filePath string, config *ParseHclConfig, diags hcl.Diagnostics) ([]byte, hcl.Diagnostics) {
-//	updatedFileData, moreDiags := EscapeTemplateTokens(fileData, filePath, config.disableTemplateForProperties)
-//	if moreDiags.HasErrors() {
-//		diags = append(diags, moreDiags...)
-//		//continue
-//	}
-//
-//	// if this modified the file data, it means the grok function is not being used - raise a warning
-//	if string(updatedFileData) != string(fileData) {
-//		diags = append(diags, &hcl.Diagnostic{
-//			Severity: hcl.DiagWarning,
-//			Summary:  "Grok expressions should be wrapped in a 'grok' function call",
-//			Detail:   fmt.Sprintf("The file %q contains a Grok expression that is not wrapped in a 'grok' function call. This has been escaped, but this funcitonalityis deprecated and will be removed in a future version.", filePath),
-//		})
-//	}
-//	fileData = updatedFileData
-//	return fileData, diags
-//}
+func applyDisableTemplateForProperties(fileData []byte, filePath string, config *ParseHclConfig, diags hcl.Diagnostics) ([]byte, hcl.Diagnostics) {
+	updatedFileData, moreDiags := EscapeTemplateTokens(fileData, filePath, config.disableTemplateForProperties)
+	if moreDiags.HasErrors() {
+		diags = append(diags, moreDiags...)
+		//continue
+	}
+
+	// if this modified the file data, it means the grok function is not being used - raise a warning
+	if string(updatedFileData) != string(fileData) {
+		diags = append(diags, &hcl.Diagnostic{
+			Severity: hcl.DiagWarning,
+			Summary:  "File layout containing '${' should be wrapped in backticks",
+			Detail:   fmt.Sprintf("The file %q contains a file layout property which is not wrapped in backticks. This has been escaped for you, however this will be deprecated in a future version. Please use backticks to escape the property.", filePath),
+		})
+	}
+	fileData = updatedFileData
+	return fileData, diags
+}
 
 func buildOrderedFileNameList(fileData map[string][]byte) []string {
 	filePaths := make([]string, len(fileData))

--- a/parse/parser_opts.go
+++ b/parse/parser_opts.go
@@ -8,7 +8,7 @@ type ParseHclOpt func(*ParseHclConfig)
 
 // WithDisableTemplateForProperties is an option to specify the properties for which
 // hcl template expression parsing should be disabled
-// this is used for preprties which will include a grok path which include the template opening chars '%{'
+// this is used for properties which will include a grok path which include the template opening chars '%{'
 // if we do not escape the '%{' for these properties, they will fail ot parse
 func WithDisableTemplateForProperties(properties []string) ParseHclOpt {
 	return func(c *ParseHclConfig) {
@@ -18,8 +18,8 @@ func WithDisableTemplateForProperties(properties []string) ParseHclOpt {
 
 // WithEscapeBackticks is an option to specify whether the grok function should be applied to the hcl file
 // this is used to escape grok expressions in the hcl file
-func WithEscapeBackticks(applyGrokFunction bool) ParseHclOpt {
+func WithEscapeBackticks(escapeBackticks bool) ParseHclOpt {
 	return func(c *ParseHclConfig) {
-		c.escapeBackticks = applyGrokFunction
+		c.escapeBackticks = escapeBackticks
 	}
 }


### PR DESCRIPTION
…