### PR TITLE
fix: InvalidRelativeTimeFormat error message (#669)

### DIFF
--- a/constants/errors.go
+++ b/constants/errors.go
@@ -16,10 +16,10 @@ const (
 
 Supported formats:
   • T-2Y   (2 years ago)
-  • T-10M  (10 months ago)
+  • T-10m  (10 months ago)
   • T-10W  (10 weeks ago)
   • T-180d (180 days ago)
   • T-9H   (9 hours ago)
-  • T-10m  (10 minutes ago)
+  • T-10M  (10 minutes ago)
 `
 )


### PR DESCRIPTION
The error was mixing 'M' with 'm'. parseRelativeTime will parse 'm' as months, and 'M' as minutes.