### PR TITLE
Use app_specific.AppName in plugin error messages. Closes #701

### DIFF
--- a/plugin/plugin_install.go
+++ b/plugin/plugin_install.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/turbot/pipe-fittings/v2/app_specific"
 	"github.com/turbot/pipe-fittings/v2/constants"
 	"github.com/turbot/pipe-fittings/v2/ociinstaller"
 	"github.com/turbot/pipe-fittings/v2/utils"
@@ -144,7 +145,8 @@ func PrintInstallReports(reports PluginInstallReports, isUpdateReport bool) {
 				utils.Pluralize("plugin", len(canBeInstalled)),
 				utils.Pluralize("is", len(canBeInstalled)),
 				constants.Bold(fmt.Sprintf(
-					"steampipe plugin install %s",
+					"%s plugin install %s",
+					app_specific.AppName,
 					strings.Join(pluginList, " "),
 				)),
 			)
@@ -162,8 +164,8 @@ func PrintInstallReports(reports PluginInstallReports, isUpdateReport bool) {
 				"To update %s %s: %s\nTo update all plugins: %s",
 				utils.Pluralize("this", len(pluginList)),
 				utils.Pluralize("plugin", len(pluginList)),
-				constants.Bold(fmt.Sprintf("steampipe plugin update %s", strings.Join(pluginList, " "))),
-				constants.Bold(fmt.Sprintln("steampipe plugin update --all")),
+				constants.Bold(fmt.Sprintf("%s plugin update %s", app_specific.AppName, strings.Join(pluginList, " "))),
+				constants.Bold(fmt.Sprintf("%s plugin update --all\n", app_specific.AppName)),
 			)
 		}
 	}


### PR DESCRIPTION
This commit updates the plugin installation and update messages to use the application-specific name (app_specific.AppName) instead of hardcoding "steampipe" in the command suggestions. The changes were made in plugin/plugin_install.go where the command suggestions in error messages and update prompts now dynamically use the application name. This makes the plugin system more flexible and consistent with the application's branding, allowing it to work correctly across different applications that use the pipe-fittings library.

The changes specifically:
- Added import for app_specific package
- Updated plugin installation command suggestions to use app_specific.AppName
- Updated plugin update command suggestions to use app_specific.AppName
- Fixed formatting of the update all plugins command message

This fix ensures that plugin-related messages and commands are properly branded according to the specific application using the pipe-fittings library.