### PR TITLE
Fix issue where system-ingestible outputs were humanised(comma separated) leading to a breaking change in Steampipe. Closes #709

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stevenle/topsort v0.2.0
 	github.com/stretchr/testify v1.10.0
-	github.com/turbot/go-kit v1.1.0
+	github.com/turbot/go-kit v1.3.0
 	github.com/xlab/treeprint v1.2.0
 	github.com/zclconf/go-cty v1.14.4
 	github.com/zclconf/go-cty-yaml v1.0.3
@@ -45,7 +45,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.27.11
 	github.com/danwakefield/fnmatch v0.0.0-20160403171240-cbb64ac3d964
 	github.com/dgraph-io/ristretto v0.2.0
-	github.com/dustin/go-humanize v1.0.1
 	github.com/goccy/go-yaml v1.11.2
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hokaccha/go-prettyjson v0.0.0-20211117102719-0474bc63780f
@@ -93,6 +92,7 @@ require (
 	github.com/containerd/platforms v0.2.1 // indirect
 	github.com/cyphar/filepath-securejoin v0.2.5 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/emirpasic/gods v1.18.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -658,8 +658,8 @@ github.com/tklauser/numcpus v0.3.0 h1:ILuRUQBtssgnxw0XXIjKUC56fgnOrFoQQ/4+DeU2bi
 github.com/tklauser/numcpus v0.3.0/go.mod h1:yFGUr7TUHQRAhyqBcEg0Ge34zDBAsIvJJcyE6boqnA8=
 github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQSepKdE=
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
-github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
-github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
+github.com/turbot/go-kit v1.3.0 h1:6cIYPAO5hO9fG7Zd5UBC4Ch3+C6AiiyYS0UQnrUlTV0=
+github.com/turbot/go-kit v1.3.0/go.mod h1:piKJMYCF8EYmKf+D2B78Csy7kOHGmnQVOWingtLKWWQ=
 github.com/turbot/pipes-sdk-go v0.12.0 h1:esbbR7bALa5L8n/hqroMPaQSSo3gNM/4X0iTmHa3D6U=
 github.com/turbot/pipes-sdk-go v0.12.0/go.mod h1:Mb+KhvqqEdRbz/6TSZc2QWDrMa5BN3E4Xw+gPt2TRkc=
 github.com/turbot/terraform-components v0.0.0-20231213122222-1f3526cab7a7 h1:qDMxFVd8Zo0rIhnEBdCIbR+T6WgjwkxpFZMN8zZmmjg=

--- a/querydisplay/column.go
+++ b/querydisplay/column.go
@@ -3,12 +3,9 @@ package querydisplay
 import (
 	"encoding/json"
 	"fmt"
-	"slices"
-	"strconv"
 	"strings"
 	"time"
 
-	"github.com/dustin/go-humanize"
 	"github.com/google/uuid"
 
 	"github.com/turbot/go-kit/helpers"
@@ -33,13 +30,24 @@ func columnNames(columns []*queryresult.ColumnDef) []string {
 	return colNames
 }
 
-type columnValueSettings struct{ nullString string }
+type columnValueSettings struct {
+	nullString     string
+	shouldHumanise bool
+}
 
 type ColumnValueOption func(opt *columnValueSettings)
 
 func WithNullString(nullString string) ColumnValueOption {
 	return func(opt *columnValueSettings) {
 		opt.nullString = nullString
+	}
+}
+
+// WithHumanisedString sets whether values should be humanised (e.g. adding commas to numbers)
+// This is used in displayLine and displayTable functions to make numbers more readable
+func WithHumanisedString(shouldHumanise bool) ColumnValueOption {
+	return func(opt *columnValueSettings) {
+		opt.shouldHumanise = shouldHumanise
 	}
 }
 
@@ -51,17 +59,16 @@ func ColumnValuesAsString(values []interface{}, columns []*queryresult.ColumnDef
 		if err != nil {
 			return nil, err
 		}
-		// TODO: #tactical local humanizeNumericStringValue function is a temporary fix and we should implement this properly in go-kit https://github.com/turbot/go-kit/issues/98
-		rowAsString[idx] = humaniseNumericStringValue(v, columns[idx].DataType)
+		rowAsString[idx] = v
 	}
 	return rowAsString, nil
 }
 
 // ColumnValueAsString converts column value to string
 func ColumnValueAsString(val interface{}, col *queryresult.ColumnDef, opts ...ColumnValueOption) (result string, err error) {
-	opt := &columnValueSettings{nullString: constants.NullString}
+	cfg := &columnValueSettings{nullString: constants.NullString}
 	for _, o := range opts {
-		o(opt)
+		o(cfg)
 	}
 
 	defer func() {
@@ -71,7 +78,7 @@ func ColumnValueAsString(val interface{}, col *queryresult.ColumnDef, opts ...Co
 	}()
 
 	if val == nil {
-		return opt.nullString, nil
+		return cfg.nullString, nil
 	}
 
 	//log.Printf("[TRACE] ColumnValueAsString type %s", colType.DatabaseTypeName())
@@ -107,11 +114,15 @@ func ColumnValueAsString(val interface{}, col *queryresult.ColumnDef, opts ...Co
 	default:
 		if strings.HasPrefix(col.DataType, "DECIMAL") {
 			// attempt to convert decimal to string, if this fails will fall through to generic formatting code
-			if str, ok := columnValueForDuckDBDecimal(val); ok {
+			if str, ok := columnValueForDuckDBDecimal(val, cfg.shouldHumanise); ok {
 				return str, nil
 			}
 		}
 
+		// use ToHumanisedString for humanised output (e.g. adding commas to numbers) or ToString for raw output
+		if cfg.shouldHumanise {
+			return typeHelpers.ToHumanisedString(val), nil
+		}
 		return typeHelpers.ToString(val), nil
 	}
 }
@@ -136,7 +147,7 @@ func ParseJSONOutputColumnValue(val interface{}, col *queryresult.ColumnDef) (in
 // we want to use the String() method on the duckDb Decimal object,
 // but we do not want to reference go-duckdb as that requires Cgo bindings
 // so instead invoke the function via reflection
-func columnValueForDuckDBDecimal(val interface{}) (string, bool) {
+func columnValueForDuckDBDecimal(val interface{}, shouldHumanise bool) (string, bool) {
 	if val == nil {
 		return "", false
 	}
@@ -144,30 +155,13 @@ func columnValueForDuckDBDecimal(val interface{}) (string, bool) {
 	s, err := helpers.ExecuteMethod(val, "String")
 	if err == nil && len(s) == 1 {
 		if str, ok := s[0].(string); ok {
+			// Apply humanisation if requested (e.g. adding commas to numbers)
+			if shouldHumanise {
+				return typeHelpers.ToHumanisedString(str), true
+			}
 			return str, true
 		}
 	}
 
 	return "", false
-}
-
-// humaniseNumericStringValue is used to determine if the number is all numeric or numeric with a single decimal point
-func humaniseNumericStringValue(s string, colType string) string {
-	ignoreTypes := []string{"JSON", "JSONB", "BOOL", "TIMESTAMP", "TIMESTAMP WITH TIME ZONE", "DATE", "TIME", "INTERVAL", "VARCHAR", "TEXT", "NAME", "UUID", "BLOB", "BIT"}
-	if s == "" || slices.Contains(ignoreTypes, colType) {
-		return s
-	}
-
-	// Attempt to parse as int, if it succeeds, format it
-	if i, err := strconv.ParseInt(s, 10, 64); err == nil {
-		return humanize.Comma(i)
-	}
-
-	// Attempt to parse as a float, if it succeeds, format the integer part and then append the decimal part
-	if f, err := strconv.ParseFloat(s, 64); err == nil {
-		return humanize.Commaf(f)
-	}
-
-	// s is not a valid number, return it as is
-	return s
 }

--- a/querydisplay/column.go
+++ b/querydisplay/column.go
@@ -30,15 +30,15 @@ func columnNames(columns []*queryresult.ColumnDef) []string {
 	return colNames
 }
 
-type columnValueSettings struct {
+type columnValueConfig struct {
 	nullString     string
 	shouldHumanise bool
 }
 
-type ColumnValueOption func(opt *columnValueSettings)
+type ColumnValueOption func(opt *columnValueConfig)
 
 func WithNullString(nullString string) ColumnValueOption {
-	return func(opt *columnValueSettings) {
+	return func(opt *columnValueConfig) {
 		opt.nullString = nullString
 	}
 }
@@ -46,7 +46,7 @@ func WithNullString(nullString string) ColumnValueOption {
 // WithHumanisedString sets whether values should be humanised (e.g. adding commas to numbers)
 // This is used in displayLine and displayTable functions to make numbers more readable
 func WithHumanisedString(shouldHumanise bool) ColumnValueOption {
-	return func(opt *columnValueSettings) {
+	return func(opt *columnValueConfig) {
 		opt.shouldHumanise = shouldHumanise
 	}
 }
@@ -66,7 +66,7 @@ func ColumnValuesAsString(values []interface{}, columns []*queryresult.ColumnDef
 
 // ColumnValueAsString converts column value to string
 func ColumnValueAsString(val interface{}, col *queryresult.ColumnDef, opts ...ColumnValueOption) (result string, err error) {
-	cfg := &columnValueSettings{nullString: constants.NullString}
+	cfg := &columnValueConfig{nullString: constants.NullString}
 	for _, o := range opts {
 		o(cfg)
 	}

--- a/querydisplay/display.go
+++ b/querydisplay/display.go
@@ -321,6 +321,7 @@ func displayLine[T queryresult.TimingContainer](ctx context.Context, result *que
 
 	// define a function to display each row
 	rowFunc := func(row []interface{}, result *queryresult.Result[T]) {
+		// since this is a pretty display format(not system ingestible), we pass WithHumanisedString(true) to make strings more readable
 		recordAsString, _ := ColumnValuesAsString(row, result.Cols, WithHumanisedString(true))
 		requiredTerminalColumnsForValuesOfRecord := 0
 		for _, colValue := range recordAsString {
@@ -423,6 +424,7 @@ func displayTable[T queryresult.TimingContainer](ctx context.Context, result *qu
 		}
 		displayRowCount++
 
+		// since this is a pretty display format(not system ingestible), we pass WithHumanisedString(true) to make strings more readable
 		rowAsString, _ := ColumnValuesAsString(row, result.Cols, WithHumanisedString(true))
 		rowObj := table.Row{}
 		for _, col := range rowAsString {

--- a/querydisplay/display.go
+++ b/querydisplay/display.go
@@ -321,7 +321,7 @@ func displayLine[T queryresult.TimingContainer](ctx context.Context, result *que
 
 	// define a function to display each row
 	rowFunc := func(row []interface{}, result *queryresult.Result[T]) {
-		recordAsString, _ := ColumnValuesAsString(row, result.Cols)
+		recordAsString, _ := ColumnValuesAsString(row, result.Cols, WithHumanisedString(true))
 		requiredTerminalColumnsForValuesOfRecord := 0
 		for _, colValue := range recordAsString {
 			colRequired := getTerminalColumnsRequiredForString(colValue)
@@ -423,7 +423,7 @@ func displayTable[T queryresult.TimingContainer](ctx context.Context, result *qu
 		}
 		displayRowCount++
 
-		rowAsString, _ := ColumnValuesAsString(row, result.Cols)
+		rowAsString, _ := ColumnValuesAsString(row, result.Cols, WithHumanisedString(true))
 		rowObj := table.Row{}
 		for _, col := range rowAsString {
 			// trim out non-displayable code-points in string


### PR DESCRIPTION
Values are now more human-readable (e.g. adding commas to numbers).

This PR fixes the issue where system ingestible formats like CSV, JSON and snapshot also had this change - which caused a breaking change in Steampipe. 