### PR TITLE
Retry OCI pull anonymously when stored credentials are rejected

### DIFF
--- a/ociinstaller/oci_downloader.go
+++ b/ociinstaller/oci_downloader.go
@@ -3,7 +3,10 @@ package ociinstaller
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"log"
+	"net/http"
 	"strings"
 
 	"github.com/containerd/containerd/remotes"
@@ -17,6 +20,7 @@ import (
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/credentials"
+	"oras.land/oras-go/v2/registry/remote/errcode"
 	"oras.land/oras-go/v2/registry/remote/retry"
 )
 
@@ -101,6 +105,21 @@ func (o *OciDownloader[I, C]) Pull(ctx context.Context, ref string, mediaTypes [
 
 	copyOpt := oras.DefaultCopyOptions
 	manifestDescriptor, err := oras.Copy(ctx, repo, tag, fileStore, tag, copyOpt)
+	if err != nil && isRegistryAuthError(err) {
+		// The first attempt used whatever the credential store returned for
+		// the host. On a 401/403 from the registry, it's useful to know
+		// whether those credentials came from the user's Docker config —
+		// an expired or revoked PAT stored there produces the same opaque
+		// "denied" error as a genuine permission problem, and the surfaced
+		// error does not mention the credential source. Retry anonymously
+		// when the store had an entry to see if the issue is stale creds.
+		if retryDesc, ok := retryAnonymouslyIfStoredCreds(ctx, repo, credStore, ref, tag, fileStore, copyOpt); ok {
+			manifestDescriptor = retryDesc
+			err = nil
+		} else {
+			err = wrapAuthError(err, ref)
+		}
+	}
 	if err != nil {
 		log.Println("[TRACE] OciDownloader.Pull:", "failed to pull", ref, err)
 		return nil, nil, nil, nil, err
@@ -181,4 +200,76 @@ func (o *OciDownloader[I, C]) newOciImage() *OciImage[I, C] {
 	}
 	o.Images = append(o.Images, i)
 	return i
+}
+
+// isRegistryAuthError reports whether err unwraps to a 401 or 403 response
+// from the OCI registry. Used to decide whether a retry without credentials
+// could recover the pull.
+func isRegistryAuthError(err error) bool {
+	var errResp *errcode.ErrorResponse
+	if errors.As(err, &errResp) {
+		return errResp.StatusCode == http.StatusUnauthorized ||
+			errResp.StatusCode == http.StatusForbidden
+	}
+	return false
+}
+
+// registryHostFromRef returns the registry host portion of an OCI image
+// reference (e.g. "ghcr.io" from "ghcr.io/turbot/steampipe/plugins/turbot/aws:1.30.2").
+// Falls back to returning the ref unchanged if it contains no path separator.
+func registryHostFromRef(ref string) string {
+	if i := strings.Index(ref, "/"); i >= 0 {
+		return ref[:i]
+	}
+	return ref
+}
+
+// retryAnonymouslyIfStoredCreds retries the copy without any credentials when
+// the credential store had an entry for the target host. The typical case:
+// the user has an expired or revoked PAT in ~/.docker/config.json (or the
+// native keychain), and the registry rejects it with DENIED even though the
+// image is publicly pullable.
+//
+// Returns the fresh manifest descriptor and true if the anonymous retry
+// succeeded. Returns the zero descriptor and false if there were no stored
+// creds (so retry would change nothing) or the anonymous retry itself failed.
+func retryAnonymouslyIfStoredCreds(
+	ctx context.Context,
+	repo *remote.Repository,
+	credStore *credentials.DynamicStore,
+	ref string,
+	tag string,
+	fileStore *file.Store,
+	copyOpt oras.CopyOptions,
+) (ocispec.Descriptor, bool) {
+	host := registryHostFromRef(ref)
+	cred, credErr := credStore.Get(ctx, host)
+	if credErr != nil || cred == auth.EmptyCredential {
+		// No stored creds for this host — the original attempt was already
+		// anonymous, so retrying won't change anything.
+		return ocispec.Descriptor{}, false
+	}
+
+	// Swap in an auth client with no credential source and retry.
+	repo.Client = &auth.Client{
+		Client: retry.DefaultClient,
+		Cache:  auth.DefaultCache,
+	}
+	desc, err := oras.Copy(ctx, repo, tag, fileStore, tag, copyOpt)
+	if err != nil {
+		log.Println("[TRACE] OciDownloader.Pull:", "anonymous retry also failed for", ref, err)
+		return ocispec.Descriptor{}, false
+	}
+
+	log.Printf("[WARN] Stored credentials for %s were rejected by the registry; pull succeeded anonymously. "+
+		"Clear the stale entry with: docker logout %s\n", host, host)
+	return desc, true
+}
+
+// wrapAuthError adds a hint about stored credentials to an auth-failure error
+// surfaced from the registry. Used when the original pull failed on auth AND
+// anonymous retry was either skipped or also failed.
+func wrapAuthError(err error, ref string) error {
+	host := registryHostFromRef(ref)
+	return fmt.Errorf("%w (if you have stored credentials for %s, they may be expired or revoked — try: docker logout %s)", err, host, host)
 }

--- a/ociinstaller/oci_downloader_test.go
+++ b/ociinstaller/oci_downloader_test.go
@@ -1,0 +1,88 @@
+package ociinstaller
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"oras.land/oras-go/v2/registry/remote/errcode"
+)
+
+func TestRegistryHostFromRef(t *testing.T) {
+	cases := map[string]string{
+		"ghcr.io/turbot/steampipe/plugins/turbot/aws:1.30.2":  "ghcr.io",
+		"ghcr.io/turbot/steampipe/plugins/turbot/aws:latest": "ghcr.io",
+		"hub.steampipe.io/plugins/turbot/aws:latest":         "hub.steampipe.io",
+		"registry.example.com:5000/org/image:tag":            "registry.example.com:5000",
+		"ghcr.io":                                            "ghcr.io",
+		"":                                                   "",
+	}
+	for ref, want := range cases {
+		if got := registryHostFromRef(ref); got != want {
+			t.Errorf("registryHostFromRef(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
+func TestIsRegistryAuthError(t *testing.T) {
+	mkErr := func(status int) error {
+		u, _ := url.Parse("https://ghcr.io/token")
+		return &errcode.ErrorResponse{
+			Method:     "GET",
+			URL:        u,
+			StatusCode: status,
+			Errors:     errcode.Errors{{Code: errcode.ErrorCodeDenied, Message: "denied"}},
+		}
+	}
+
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"plain error", errors.New("network unreachable"), false},
+		{"401 Unauthorized", mkErr(http.StatusUnauthorized), true},
+		{"403 Forbidden", mkErr(http.StatusForbidden), true},
+		{"404 Not Found", mkErr(http.StatusNotFound), false},
+		{"500 Server Error", mkErr(http.StatusInternalServerError), false},
+		{"wrapped 403", fmt.Errorf("resolving manifest: %w", mkErr(http.StatusForbidden)), true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isRegistryAuthError(tc.err); got != tc.want {
+				t.Errorf("isRegistryAuthError(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWrapAuthError(t *testing.T) {
+	inner := errors.New("response status code 403: denied: denied")
+	wrapped := wrapAuthError(inner, "ghcr.io/turbot/steampipe/plugins/turbot/aws:1.30.2")
+
+	msg := wrapped.Error()
+	if !contains(msg, "denied: denied") {
+		t.Errorf("wrapped error lost original message, got: %s", msg)
+	}
+	if !contains(msg, "ghcr.io") {
+		t.Errorf("wrapped error missing host hint, got: %s", msg)
+	}
+	if !contains(msg, "docker logout") {
+		t.Errorf("wrapped error missing docker logout hint, got: %s", msg)
+	}
+	if !errors.Is(wrapped, inner) {
+		t.Errorf("errors.Is should still see the original error through the wrap")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	for i := 0; i+len(needle) <= len(haystack); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
Closes #793

## Summary

When `~/.docker/config.json` (or the OS native keychain) contains an expired/revoked GitHub PAT for `ghcr.io`, `oras-go` picks it up silently and presents it to the registry. GHCR responds `403 denied: denied`, the CLI surfaces an opaque error naming `ghcr.io/token` as the failing URL, and plugin installation aborts — even though the image is publicly pullable.

This PR makes the downloader retry once without credentials when:
- `oras.Copy` failed with HTTP 401 or 403
- AND the credential store had an entry for the target host

Outcomes:

| Original | Retry | User sees |
|---|---|---|
| auth error with stored creds | succeeds | **install completes**, WARN log tells user to `docker logout <host>` |
| auth error with stored creds | still fails | original error surfaced, wrapped with the same `docker logout` hint |
| auth error without stored creds | — | no retry (first attempt was already anonymous); original error as before |
| non-auth error (network/404/5xx) | — | no change — not a credentials problem |

Affects every downstream that uses `pipe-fittings/ociinstaller` — Steampipe, Tailpipe, Powerpipe, Flowpipe — automatically on the next module bump, no CLI changes needed.

## Files touched

- `ociinstaller/oci_downloader.go` — retry flow in `Pull()` plus helpers (`isRegistryAuthError`, `registryHostFromRef`, `retryAnonymouslyIfStoredCreds`, `wrapAuthError`)
- `ociinstaller/oci_downloader_test.go` (new) — unit tests for the helpers

## Test plan

- [x] `go test ./ociinstaller/...` passes locally
- [x] `go vet ./ociinstaller/...` clean
- [x] Manual reproduction end-to-end: planted a bogus ghcr.io credential in the macOS keychain via `docker-credential-osxkeychain store`. System steampipe binary fails with `response status code 403: denied: denied`. Steampipe built with this branch via replace directive installs successfully and logs the stored-creds WARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)