### PR TITLE
v2.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Shared Pipes Component
 
+## v2.9.1 [2026-04-21]
+
+* Fix OCI plugin installs silently failing when stored Docker credentials for the registry are stale or revoked. The downloader now retries once anonymously on 401/403 when the credential store had an entry for the host, and warns the user to clear the stale entry with `docker logout <host>`. Closes #793.
+
 ## v2.9.0 [2026-03-24]
 
 * Replace standalone `pgconn` with `pgx/v5/pgconn` to fix CVE-2026-4427 (pgproto3/v2 DoS). Closes #784.


### PR DESCRIPTION
## Summary

Adds the CHANGELOG entry for v2.9.1. The fix itself landed in #792.

Tag v2.9.1 on the squash-merge commit of this PR once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)