### PR TITLE
Make mod install tolerate read-only git pack files (v1.7.x backport)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 Shared Pipes Component
 
+## v1.7.4 [2026-06-23]
+
+_Bug fixes_
+
+* Fixed mod install failing with `permission denied` on a re-install or upgrade. go-git (>= v5.17) writes git pack files read-only, which the shared mod installer's shadow-directory commit could not overwrite. ([#802](https://github.com/turbot/pipe-fittings/pull/802))
+
 ## v1.7.3 [2024-01-07]
 
 _What's new_

--- a/modinstaller/mod_installer.go
+++ b/modinstaller/mod_installer.go
@@ -273,11 +273,42 @@ func (i *ModInstaller) commitShadow(ctx context.Context) error {
 		source := filepath.Join(i.shadowDirPath, entry.Name())
 		destination := filepath.Join(i.modsPath, entry.Name())
 		slog.Debug("copying", source, destination)
+		// the recursive copy truncates existing destination files via os.Create, which
+		// fails on a read-only file. go-git (>= v5.17) writes git pack files read-only,
+		// so a mod re-install or upgrade leaves read-only *.pack/*.idx in the destination;
+		// restore write permission first so they can be overwritten.
+		if err := makeTreeWritable(destination); err != nil {
+			return fmt.Errorf("could not prepare destination '%s' for commit: %w", entry.Name(), err)
+		}
 		if err := copy.Copy(source, destination); err != nil {
 			return fmt.Errorf("could not commit shadow directory '%s': %w", entry.Name(), err)
 		}
 	}
 	return nil
+}
+
+// makeTreeWritable adds owner-write permission to every file and directory under root
+// (which may not exist - a missing root is not an error). It exists because go-git
+// (>= v5.17) writes git pack files read-only (0444); commitShadow's recursive copy
+// cannot truncate a read-only destination file, so a mod re-install/upgrade fails with
+// "permission denied" without this.
+func makeTreeWritable(root string) error {
+	if _, err := os.Stat(root); os.IsNotExist(err) {
+		return nil
+	}
+	return filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		if info.Mode()&0o200 != 0 {
+			return nil
+		}
+		return os.Chmod(p, info.Mode()|0o200)
+	})
 }
 
 func (i *ModInstaller) shouldCommitShadow(ctx context.Context, installError error) bool {

--- a/modinstaller/mod_installer_test.go
+++ b/modinstaller/mod_installer_test.go
@@ -9,6 +9,7 @@ import (
 
 // TestCommitShadowOverwritesReadOnlyFiles reproduces a mod re-install/upgrade where the
 // destination already holds read-only git pack files (as written by go-git >= v5.17).
+// (pipe-fittings' own go.mod pins go-git below this; consumers such as flowpipe float it higher.)
 // commitShadow must overwrite them rather than fail with "permission denied".
 func TestCommitShadowOverwritesReadOnlyFiles(t *testing.T) {
 	tmp := t.TempDir()

--- a/modinstaller/mod_installer_test.go
+++ b/modinstaller/mod_installer_test.go
@@ -22,10 +22,10 @@ func TestCommitShadowOverwritesReadOnlyFiles(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(destPack), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(destPack, []byte("old"), 0o444); err != nil {
+	if err := os.WriteFile(destPack, []byte("old"), 0o600); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.Chmod(destPack, 0o444); err != nil {
+	if err := os.Chmod(destPack, 0o400); err != nil { // read-only, as go-git leaves packs
 		t.Fatal(err)
 	}
 
@@ -34,7 +34,7 @@ func TestCommitShadowOverwritesReadOnlyFiles(t *testing.T) {
 	if err := os.MkdirAll(filepath.Dir(shadowPack), 0o755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(shadowPack, []byte("new"), 0o444); err != nil {
+	if err := os.WriteFile(shadowPack, []byte("new"), 0o600); err != nil {
 		t.Fatal(err)
 	}
 

--- a/modinstaller/mod_installer_test.go
+++ b/modinstaller/mod_installer_test.go
@@ -1,0 +1,52 @@
+package modinstaller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestCommitShadowOverwritesReadOnlyFiles reproduces a mod re-install/upgrade where the
+// destination already holds read-only git pack files (as written by go-git >= v5.17).
+// commitShadow must overwrite them rather than fail with "permission denied".
+func TestCommitShadowOverwritesReadOnlyFiles(t *testing.T) {
+	tmp := t.TempDir()
+	modsPath := filepath.Join(tmp, "mods")
+	shadowPath := filepath.Join(tmp, "shadow")
+
+	// a previously installed mod, with a read-only pack file (mimics go-git output)
+	packRel := filepath.Join("github.com", "turbot", "mod", ".git", "objects", "pack", "pack-abc.idx")
+	destPack := filepath.Join(modsPath, packRel)
+	if err := os.MkdirAll(filepath.Dir(destPack), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destPack, []byte("old"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(destPack, 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	// the shadow directory holds the new version of the same file, also read-only
+	shadowPack := filepath.Join(shadowPath, packRel)
+	if err := os.MkdirAll(filepath.Dir(shadowPack), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(shadowPack, []byte("new"), 0o444); err != nil {
+		t.Fatal(err)
+	}
+
+	i := &ModInstaller{modsPath: modsPath, shadowDirPath: shadowPath}
+	if err := i.commitShadow(context.Background()); err != nil {
+		t.Fatalf("commitShadow failed overwriting read-only destination: %v", err)
+	}
+
+	got, err := os.ReadFile(destPack)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "new" {
+		t.Fatalf("destination not updated: got %q, want %q", string(got), "new")
+	}
+}


### PR DESCRIPTION
Backport of the v2 `develop` fix (#801) to the `v1.7.x` line, for flowpipe (pinned to pipe-fittings v1.7.2).

## Problem

go-git (>= v5.17) writes git pack files (`*.pack`, `*.idx`) read-only (0444) via `fixPermissions()`. `modinstaller.commitShadow` copies the staged shadow directory into the live mods directory with a recursive copy that truncates existing destination files via `os.Create`, which fails with `permission denied` on a read-only file:

```
Error: could not commit shadow directory 'github.com': open .../.git/objects/pack/pack-<hash>.idx: permission denied
```

First install works; a re-install/upgrade fails. Same regression as powerpipe#1040. flowpipe floats go-git to 5.19.1, so it is affected once a mod is upgraded/reinstalled.

## Why the upstream go-git fix does not cover this

go-git fixed its own side in v5.17.2 (go-git/go-git#1942), but that only stops go-git re-writing packs inside a repo it manages. Our failure is `commitShadow`'s `otiai10/copy` overwriting a read-only pack in the **mods** directory. powerpipe's CI confirmed the go-git 5.19.1 bump (which includes v5.17.2) still fails — so the fix has to be on our side.

## Fix

Restore owner-write permission on the destination tree before the copy. `makeTreeWritable` is a no-op when the destination does not exist and only adds the owner-write bit where missing.

## Test

`TestCommitShadowOverwritesReadOnlyFiles` commits a shadow directory over a read-only destination pack file — the upgrade/reinstall path existing tests do not cover. Without the fix it reproduces the exact production error; with it the destination is overwritten.

gofmt clean, `go vet ./modinstaller/` clean, `go test ./modinstaller/` passes.
